### PR TITLE
fix: prevent division by zero in findMin function

### DIFF
--- a/modulo2-Cálculo-Diferencial/Otimização de uma função quadrática/QuadraticOptimization.java
+++ b/modulo2-Cálculo-Diferencial/Otimização de uma função quadrática/QuadraticOptimization.java
@@ -12,6 +12,9 @@ public class QuadraticOptimization {
 
     // Função para encontrar o ponto de mínimo
     public static double findMin(double a, double b, double c) {
+        if (a == 0) {
+            throw new ArithmeticException("não é possível dividir por zero");
+        }
         // O ponto de mínimo para uma função quadrática ocorre em x = -b / (2a)
         return -b / (2 * a);
     }


### PR DESCRIPTION
This pull request fixes a potential issue in the findMin method of the QuadraticOptimization class, where dividing by zero could return Infinity or -Infinity when the coefficient a is zero.

when the ```a``` is ```zero``` this happen:

```bash
O ponto de mínimo ocorre em x = Infinity
O valor mínimo da função é f(x) = NaN
```